### PR TITLE
fix: use ntriples as default format from neptune and remove %e format

### DIFF
--- a/lib/Format.php
+++ b/lib/Format.php
@@ -588,11 +588,11 @@ Format::register(
     'N-Triples',
     'http://www.w3.org/TR/n-triples/',
     array(
-        'application/n-triples' => 0.8,
+        'application/n-triples' => 1,
         'text/plain' => 0.8,
-        'text/ntriples' => 0.8,
-        'application/ntriples' => 0.8,
-        'application/x-ntriples' => 0.8
+        'text/ntriples' => 0.9,
+        'application/ntriples' => 0.9,
+        'application/x-ntriples' => 0.9
     ),
     array('nt')
 );
@@ -602,9 +602,9 @@ Format::register(
     'Turtle Terse RDF Triple Language',
     'http://www.dajobe.org/2004/01/turtle',
     array(
-        'text/turtle' => 0.9,
-        'application/turtle' => 0.9,
-        'application/x-turtle' => 1.0
+        'text/turtle' => 0.8,
+        'application/turtle' => 0.8,
+        'application/x-turtle' => 0.8 
     ),
     array('ttl')
 );

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -146,11 +146,11 @@ class Turtle extends Serialiser
 
         if ($datatype = $literal->getDatatypeUri()) {
             if ($datatype == 'http://www.w3.org/2001/XMLSchema#integer') {
-                return sprintf('%d', $value);
+                return sprintf('%s', $value);
             } elseif ($datatype == 'http://www.w3.org/2001/XMLSchema#decimal') {
                 return sprintf('%s', $value);
             } elseif ($datatype == 'http://www.w3.org/2001/XMLSchema#double') {
-                return sprintf('%e', $value);
+                return sprintf('%s', $value);
             } elseif ($datatype == 'http://www.w3.org/2001/XMLSchema#boolean') {
                 return sprintf('%s', $value);
             } else {


### PR DESCRIPTION
1. Change default format from neptune to ntriples
This was done because neptune's turtle serialiser was outputting
scientific notation which we didn't want because it wouldn't match when
doing the update later.  We want the actual value in the database.
Ntriples doesn't get serialsied with scientific notation

2. Change turtle serialiser in easyrdf to sprintf with %s rather than %e
because we don't want rounding or conversion to scientific notation.